### PR TITLE
Allow for further fields to be specified manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To ensure the beacon picks up all the relevant information, make sure your setup
 ```js
 import Beacon from 'sig-beacon'; // NPM
 /* OR */
-import Beacon from "https://cdn.jsdelivr.net/npm/sig-beacon@0.0.10/index.js"; // CDN
+import Beacon from "https://cdn.jsdelivr.net/npm/sig-beacon@0.0.11/index.js"; // CDN
 
 const beacon = new Beacon("<BASE_RELAY_URL>");
 await beacon.signal();

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ export default class Beacon {
   specifiedName;
   /** @type {string} The description of the app, if specified. Overrides page checks. */
   specifiedDescription;
+  /** @type {string} The canonical URL of the app, if specified. Overrides page checks. */
+  specifiedUrl;
   /** @type {boolean} Whether the beacon is currently in a browser context */
   browserContext = 'document' in globalThis;
   /** @type {Document} The top-level HTML document, if we detect we are running in an iframe. */
@@ -29,6 +31,7 @@ export default class Beacon {
     if (override) {
       this.specifiedName = override.name ?? null;
       this.specifiedDescription = override.description ?? null;
+      this.specifiedUrl = override.url ?? null;
     }
   }
 
@@ -37,6 +40,8 @@ export default class Beacon {
    * @returns {string}
    */
   getUrl() {
+    if (this.specifiedUrl) return this.specifiedUrl;
+
     const document = this.topLevelDocument ?? window.document;
     const og = document.head.querySelector('meta[property="og:url"]');
     const meta = document.head.querySelector('meta[data-canonical-url]');

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ export default class Beacon {
   specifiedDescription;
   /** @type {string} The canonical URL of the app, if specified. Overrides page checks. */
   specifiedUrl;
+  /** @type {string} The preview image of the app, if specified. Overrides page checks. */
+  specifiedImage;
+  /** @type {string} The tags for the app, if specified. Overrides page checks. */
+  specifiedTags;
   /** @type {boolean} Whether the beacon is currently in a browser context */
   browserContext = 'document' in globalThis;
   /** @type {Document} The top-level HTML document, if we detect we are running in an iframe. */
@@ -32,6 +36,8 @@ export default class Beacon {
       this.specifiedName = override.name ?? null;
       this.specifiedDescription = override.description ?? null;
       this.specifiedUrl = override.url ?? null;
+      this.specifiedImage = override.image ?? null;
+      this.specifiedTags = override.tags ?? null;
     }
   }
 
@@ -99,6 +105,8 @@ export default class Beacon {
    * @returns {Promise<string>}
    */
   async getImage() {
+    if (this.specifiedImage) return this.specifiedImage;
+
     const document = this.topLevelDocument ?? window.document;
     const meta = document.head.querySelector('meta[property="og:image"]');
 
@@ -164,6 +172,8 @@ export default class Beacon {
    * @returns {string}
    */
   getTags() {
+    if (this.specifiedTags) return this.specifiedTags;
+
     const document = this.topLevelDocument ?? window.document;
     const meta = document.head.querySelector('meta[name="keywords"]');
     if (meta) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sig-beacon",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Allows canonical URL, preview image, and tags to be specified manually. Helps make things more consistent and facilitates easier usage in Unity SDK integration.