### PR TITLE
feat: Begin sending heartbeats to relay after initial signal

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ export default class Beacon {
       this.specifiedImage = override.image ?? null;
       this.specifiedTags = override.tags ?? null;
     }
+
+    this.sessionId = crypto.randomUUID();
   }
 
   /**
@@ -235,5 +237,23 @@ export default class Beacon {
         'Content-Type': 'application/json'
       }
     });
+    const heartbeat = setInterval(async () => {
+      try {
+        await fetch(`${this.relay}/session`, {
+          method: 'POST',
+          body: JSON.stringify({
+            session_id: this.sessionId,
+            url,
+            timestamp: Date.now(),
+          }),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+      } catch {
+        console.error("Failed to send heartbeat signal! Relay server is not reachable.")
+        clearInterval(heartbeat);
+      }
+    }, 5000);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sig-beacon",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Companion PR to the most recent relay PR. This sends a recurring heartbeat signal to the relay after initial signalling, allowing the relay to keep track of how many users are currently active within a given app. Important to note that these heartbeat signals don't send any personal data of the user: sessions are identified solely by a randomly generated uuidv4 string and a timestamp. The heartbeat signal will abort if it is unable to successfully post to the `/session` endpoint on the chosen relay for the beacon.