### PR TITLE
Strip query params from URLs by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sig-beacon",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This updates the beacon behavior to strip query params from dynamically grabbed URLs by default so as to avoid creating redundant entries on the connected relay. This behavior can be overridden in the event that a site uses query params to load distinct/separate experiences.